### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Go Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,13 @@
 name: Go Tests
-permissions:
-  contents: read
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/gh-add-files/security/code-scanning/1](https://github.com/advanced-security/gh-add-files/security/code-scanning/1)

To fix the issue, add a `permissions` block specifying only the minimal access necessary for workflow steps. For this Go test workflow, steps only require the ability to read repository contents; no `write` permissions are needed. The best practice is to add `permissions: contents: read` at the workflow root, ensuring all jobs default to read-only access. This involves inserting the following block after the workflow `name` and before the `on` directive:

```yaml
permissions:
  contents: read
```

No modifications to workflow job steps are required beyond this.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
